### PR TITLE
[Fix] play.py cannot override agent_cfg from command line argument

### DIFF
--- a/scripts/rsl_rl/play.py
+++ b/scripts/rsl_rl/play.py
@@ -65,7 +65,7 @@ from whole_body_tracking.utils.exporter import attach_onnx_metadata, export_moti
 @hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
 def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlOnPolicyRunnerCfg):
     """Play with RSL-RL agent."""
-    agent_cfg: RslRlOnPolicyRunnerCfg = cli_args.parse_rsl_rl_cfg(args_cli.task, args_cli)
+    agent_cfg: RslRlOnPolicyRunnerCfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
     env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
 
     # specify directory for logging experiments


### PR DESCRIPTION

**Problem**
After Hydra integration to `play.py`, the agent configuration is already built from the entry-point yaml and updated with any command-line overrides.
However, the legacy call to `parse_rsl_rl_cfg` is still executed inside main, which discards the Hydra-supplied config and rebuilds it from scratch, losing all overrides.

**Fix**
Replace the redundant `parse_rsl_rl_cfg` with `update_rsl_rl_cfg`, which only patches the already-constructed config with CLI flags that are not managed by Hydra (e.g. checkpoint path).
This guarantees that Hydra’s command-line overrides are preserved while keeping the extra CLI tweaks intact.

**Original Code**:
```bash

@hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlOnPolicyRunnerCfg):
    """Play with RSL-RL agent."""
    agent_cfg: RslRlOnPolicyRunnerCfg = cli_args.parse_rsl_rl_cfg(args_cli.task, args_cli)
```

**Corrected Code**:
```bash

@hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlOnPolicyRunnerCfg):
    """Play with RSL-RL agent."""
    agent_cfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
```